### PR TITLE
Update olc::Renderable Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ olc::AnimatedSprite sprite;
 bool OnUserCreate()
 {
     // configure the sprite:
+    olc::Renderable spritesheet = new olc::Renderable();
+    spritesheet.Load("spritesheet.png");
     sprite.mode = olc::AnimatedSprite::SPRITE_MODE::SINGLE; // set sprite to use a single spritesheet
-    sprite.spriteSheet = new olc::Renderable("spritesheet.png"); // define image to use for the spritesheet
+    sprite.spriteSheet = spritesheet; // define image to use for the spritesheet
     sprite.SetSpriteSize({50, 50}); // define size of each sprite with an olc::vi2d
     sprite.SetSpriteScale(2.0f); // define scale of sprite; 1.0f is original size. Must be above 0 and defaults to 1.0f
 

--- a/olcPGEX_AnimatedSprite.h
+++ b/olcPGEX_AnimatedSprite.h
@@ -66,18 +66,6 @@
 
 namespace olc
 {
-	class Renderable
-	{
-	public:
-		Renderable() = default;
-		Renderable(std::string spriteLocation);
-		~Renderable();
-
-	public:
-		olc::Sprite* sprite = nullptr;
-		olc::Decal* decal = nullptr;
-	};
-
 	class AnimatedSprite : public olc::PGEX
 	{
 	public:
@@ -149,16 +137,6 @@ namespace olc
 
 namespace olc
 {
-	Renderable::Renderable(std::string spriteLocation) {
-		sprite = new Sprite(spriteLocation);
-		decal = new Decal(sprite);
-	}
-
-	Renderable::~Renderable() {
-		delete decal;
-		delete sprite;
-	}
-
 	olc::Sprite* AnimatedSprite::GetMultiFrame(float fElapsedTime)
 	{
 		frameTimer += fElapsedTime;
@@ -208,7 +186,7 @@ namespace olc
 			}
 		}
 
-		return multiRenderables[state][currentFrame]->decal;
+		return multiRenderables[state][currentFrame]->Decal();
 	}
 
 	olc::vi2d AnimatedSprite::GetSingleFrame(float fElapsedTime)
@@ -282,7 +260,8 @@ namespace olc
 			if (type == SPRITE_TYPE::SPRITE) {
 				multiFrames[stateName].push_back(new olc::Sprite(path));
 			} else {
-				multiRenderables[stateName].push_back(new Renderable(path));
+				multiRenderables[stateName].push_back(new Renderable());
+				multiRenderables[stateName].back()->Load(path);
 			}
 		}
 
@@ -335,9 +314,9 @@ namespace olc
 		}
 		else {
 			if (type == SPRITE_TYPE::SPRITE) {
-				pge->DrawPartialSprite(position, spriteSheet->sprite, GetSingleFrame(fElapsedTime), spriteSize, spriteScale, flip);
+				pge->DrawPartialSprite(position, spriteSheet->Sprite(), GetSingleFrame(fElapsedTime), spriteSize, spriteScale, flip);
 			} else {
-				pge->DrawPartialDecal(GetDecalPosition(position, flip), spriteSheet->decal, GetSingleFrame(fElapsedTime), spriteSize, GetDecalScale(flip), tint);
+				pge->DrawPartialDecal(GetDecalPosition(position, flip), spriteSheet->Decal(), GetSingleFrame(fElapsedTime), spriteSize, GetDecalScale(flip), tint);
 			}
 		}
 	}


### PR DESCRIPTION
- Remove `olc::Renderable` from the PGEX header
- Use `olc::Renderable` from main PixelGameEngine header
- Update usage accordingly
- Update README.md to reflect usage changes